### PR TITLE
reduce severity of log to info in case of flush on non-existing member

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -168,11 +168,23 @@ void FdbOrch::update(sai_fdb_event_t        type,
                    type, update.entry.mac.to_string().c_str(),
                    entry->bv_id, bridge_port_id);
 
+
     if (bridge_port_id &&
         !m_portsOrch->getPortByBridgePortId(bridge_port_id, update.port))
     {
-        SWSS_LOG_ERROR("Failed to get port by bridge port ID 0x%" PRIx64 ".",
+        if (type == SAI_FDB_EVENT_FLUSHED)
+        {
+            /* in case of flush - can be ignored due to a race */
+            /* there are notifications about FDB FLUSH (syncd/sai_redis) on port which was already removed
+             * by orchagent as a result of removeVlanMember action (removeBridgePort) */
+            SWSS_LOG_INFO("Flush ignored. Received event on bridge port ID 0x%" PRIx64 " which is not exist.",
                         bridge_port_id);
+
+        } else {
+            SWSS_LOG_ERROR("Failed to get port by bridge port ID 0x%" PRIx64 ".",
+                        bridge_port_id);
+
+        }
         return;
     }
 
@@ -263,7 +275,7 @@ void FdbOrch::update(sai_fdb_event_t        type,
             {
                 /*port added back to vlan before we receive delete
                   notification for flush from SAI. Re-add entry to SAI
-                 */ 
+                 */
                 sai_attribute_t attr;
                 vector<sai_attribute_t> attrs;
 
@@ -286,7 +298,7 @@ void FdbOrch::update(sai_fdb_event_t        type,
 
         update.add = false;
         if (!update.port.m_alias.empty())
-        { 
+        {
             update.port.m_fdb_count--;
             m_portsOrch->setPort(update.port.m_alias, update.port);
         }
@@ -1036,8 +1048,8 @@ bool FdbOrch::addFdbEntry(const FdbEntry& entry, const string& port_name,
         attr.value.ipaddr = ipaddr;
         attrs.push_back(attr);
     }
-    else if (macUpdate 
-            && (oldOrigin == FDB_ORIGIN_VXLAN_ADVERTIZED) 
+    else if (macUpdate
+            && (oldOrigin == FDB_ORIGIN_VXLAN_ADVERTIZED)
             && (fdbData.origin != oldOrigin))
     {
         /* origin is changed from Remote-advertized to Local-provisioned
@@ -1051,7 +1063,7 @@ bool FdbOrch::addFdbEntry(const FdbEntry& entry, const string& port_name,
         attrs.push_back(attr);
     }
 
-    if (macUpdate && (oldOrigin == FDB_ORIGIN_VXLAN_ADVERTIZED)) 
+    if (macUpdate && (oldOrigin == FDB_ORIGIN_VXLAN_ADVERTIZED))
     {
         if ((fdbData.origin != oldOrigin)
            || ((oldType == "dynamic") && (oldType != fdbData.type)))
@@ -1062,7 +1074,7 @@ bool FdbOrch::addFdbEntry(const FdbEntry& entry, const string& port_name,
         }
     }
 
-    
+
     if (macUpdate)
     {
         SWSS_LOG_INFO("MAC-Update FDB %s in %s on from-%s:to-%s from-%s:to-%s origin-%d-to-%d",
@@ -1225,7 +1237,7 @@ bool FdbOrch::removeFdbEntry(const FdbEntry& entry, FdbOrigin origin)
     (void)m_entries.erase(entry);
 
     // Remove in StateDb
-    if (fdbData.origin != FDB_ORIGIN_VXLAN_ADVERTIZED) 
+    if (fdbData.origin != FDB_ORIGIN_VXLAN_ADVERTIZED)
     {
         m_fdbStateTable.del(key);
     }
@@ -1245,7 +1257,7 @@ bool FdbOrch::removeFdbEntry(const FdbEntry& entry, FdbOrigin origin)
     return true;
 }
 
-void FdbOrch::deleteFdbEntryFromSavedFDB(const MacAddress &mac, 
+void FdbOrch::deleteFdbEntryFromSavedFDB(const MacAddress &mac,
         const unsigned short &vlanId, FdbOrigin origin, const string portName)
 {
     bool found=false;
@@ -1268,7 +1280,7 @@ void FdbOrch::deleteFdbEntryFromSavedFDB(const MacAddress &mac,
                     if (iter->fdbData.origin == origin)
                     {
                         SWSS_LOG_INFO("FDB entry found in saved fdb. deleting..."
-                                "mac=%s vlan_id=0x%x origin:%d port:%s", 
+                                "mac=%s vlan_id=0x%x origin:%d port:%s",
                                 mac.to_string().c_str(), vlanId, origin,
                                 itr.first.c_str());
                         saved_fdb_entries[itr.first].erase(iter);
@@ -1280,7 +1292,7 @@ void FdbOrch::deleteFdbEntryFromSavedFDB(const MacAddress &mac,
                     {
                         SWSS_LOG_INFO("FDB entry found in saved fdb, but Origin is "
                                 "different mac=%s vlan_id=0x%x reqOrigin:%d "
-                                "foundOrigin:%d port:%s, IGNORED", 
+                                "foundOrigin:%d port:%s, IGNORED",
                                 mac.to_string().c_str(), vlanId, origin,
                                 iter->fdbData.origin, itr.first.c_str());
                     }


### PR DESCRIPTION
Signed-off-by: allas <allas@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Reduced severity of log to info in case of flush on non-existing member.

**Why I did it**
There is a race in the infra which can cause the scenario, when we receives notifications about FDB FLUSH on port which was already removed.

**How I verified it**
    >  sudo config vlan add 3
    >  sudo config vlan member add 3 Ethernet8
    >  sudo config vlan member del 3 Ethernet8

**Details if related**
